### PR TITLE
corrected the last grid with 60px

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
       
       div + div + div + div + div + div + div > div.container{
         display: grid;
-        grid-template-columns: 50px 1fr 200px;
+        grid-template-columns: 60px 1fr 200px;
         gap: 5px;
       }
 
@@ -103,6 +103,7 @@
         grid-template-columns: 1fr 1fr 1fr;
         gap: 5px;
       }
+ 
       
     </style>
   </head>


### PR DESCRIPTION
Hi Lee! The width of the first column should be 60px to accommodate the 5px from the gap. Not sure if I'm making sense. This is what we had before:
![image](https://user-images.githubusercontent.com/126499060/227368299-8c21e155-8fb0-4cb2-87b8-151a4bab9d13.png)
